### PR TITLE
fix: WMClass from firefox to Firefox

### DIFF
--- a/desktop/firefox.desktop
+++ b/desktop/firefox.desktop
@@ -119,7 +119,7 @@ X-MultipleArgs=false
 Type=Application
 MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;application/x-xpinstall;application/pdf;application/json;
 StartupNotify=true
-StartupWMClass=firefox
+StartupWMClass=Firefox
 Categories=Network;WebBrowser;
 Actions=new-window;new-private-window;
 


### PR DESCRIPTION
The `WM_CLASS` of Firefox is: `WM_CLASS(STRING) = "Navigator", "Firefox"`. Using `firefox` instead of `Firefox` causes blurred icon on [`plank`](https://archlinux.org/packages/community/x86_64/plank/). I'm not sure if `WM_CLASS` of other versions of Firefox (beta, esr & nightly) is the same (ie. `Firefox`). If someone can confirm it, I'll add those changes too.