### PR TITLE
Don't use deprecated artifact actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         echo "$FIREFOX_VERSION.r$FIREFOX_BUILD_ID"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.product }}-continuous.AppImage
         path: 'dist'

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ zap install --github --from=srevinsaju/Firefox-AppImage firefox-appimage
 
 ### Executing
 #### File Manager
-Just double click the `*.AppImage` file and you are done.
+Double-click the `*.AppImage` file, and you are done.
 
-> In normal cases, the above method should work, but in some rare cases
-the `+x` permissisions. So, right click > Properties > Allow Execution
+> In normal cases, the above method should work, but in some rare cases,
+the `+x` permissions. So, right click > Properties > Allow Execution
 
 #### Terminal 
 ```bash
@@ -45,7 +45,7 @@ chmod +x Firefox-*.AppImage
 ./Firefox-*.AppImage
 ```
 
-In case, if FUSE support libraries are not installed on the host system, it is 
+In case FUSE libraries are not installed on the host system, it is 
 still possible to run the AppImage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ zap install --github --from=srevinsaju/Firefox-AppImage firefox-appimage
 
 ### Executing
 #### File Manager
-Just double click the `*.AppImage` file and you are done!
+Just double click the `*.AppImage` file and you are done.
 
 > In normal cases, the above method should work, but in some rare cases
 the `+x` permissisions. So, right click > Properties > Allow Execution


### PR DESCRIPTION
Use v4 instead of v1 for artifact actions since v1 and v2 are [deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).

I also slightly updated the README for grammar.